### PR TITLE
Update cfgreg.c

### DIFF
--- a/src/cfgreg.c
+++ b/src/cfgreg.c
@@ -91,10 +91,10 @@ ninetails_detect(void)
 #ifdef DEBUG
 	printf("DEBUG: running detection procedure\n");
 #endif /* DEBUG */
-	l0 = cfgreg_read(CFG_LOCK0_OFFSET);	
-	l1 = cfgreg_read(CFG_LOCK1_OFFSET);	
-	l2 = cfgreg_read(CFG_LOCK2_OFFSET);	
-	l3 = cfgreg_read(CFG_LOCK3_OFFSET);	
+	l0 = ( cfgreg_read(CFG_LOCK0_OFFSET) & 0xF0 ) ;	
+	l1 = ( cfgreg_read(CFG_LOCK1_OFFSET) & 0xF0 );	
+	l2 = ( cfgreg_read(CFG_LOCK2_OFFSET) & 0xF0 );	
+	l3 = ( cfgreg_read(CFG_LOCK3_OFFSET) & 0xF0 );	
 
 	if ((l0 == CFG_LOCK0_ID_REV0) &&
 	    (l1 == CFG_LOCK1_ID_REV0) &&


### PR DESCRIPTION
Using AND operation to set unused bits to 0 (possibility of reading random data at bits 3-0 of l0, l1, l2, l3 - those pins are not tied to cpld, so they can hold previously writted/read data).
